### PR TITLE
Update fakexrandr-manage.py

### DIFF
--- a/fakexrandr-manage.py
+++ b/fakexrandr-manage.py
@@ -34,6 +34,8 @@ import struct
 import sys
 
 try:
+    import gi
+    gi.require_version('Gtk', '3.0')
     from gi.repository import Gtk, Gdk
     HAS_GTK=True
 except ImportError:


### PR DESCRIPTION
Fix for Ubuntu 21.10 with python3.